### PR TITLE
Remove PR approval requirement

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -49,11 +49,9 @@ branches:
       # Require linear history (fast-forward only)
       required_linear_history: true
 
-      # Require PRs to release (no direct pushes)
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: false
-        require_code_owner_reviews: false
+      # No PR requirement (single developer - can't self-approve)
+      # Use PRs as best practice, but rely on tests + linear history
+      required_pull_request_reviews: null
 
       # Enforce on admins (prevents accidental pushes, use break glass if needed)
       enforce_admins: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,6 +11,12 @@ repository:
   has_wiki: false
   has_downloads: true
 
+  # Merge settings - disable all merge methods to prevent accidental SHA changes
+  # Use CLI for fast-forward merges to keep branches in sync
+  allow_merge_commit: false  # No merge commits
+  allow_squash_merge: false  # No squash
+  allow_rebase_merge: false  # No rebase (creates new SHAs)
+
 branches:
   - name: main
     protection:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Run tests
+    name: test
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Update branch protection settings:
- Remove PR approval requirement (can't self-approve)
- Keep tests, linear history, and admin enforcement
- Includes break glass documentation