### PR TITLE
Add cache versioning for thumbnail invalidation

### DIFF
--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -4,6 +4,7 @@ import { handleGetFile } from "./handlers/media";
 interface Env {
   R2_BUCKET: R2Bucket;
   DB: D1Database;
+  CACHE_VERSION: KVNamespace;
   GALLERY_PASSWORD?: string; // Simple password for gallery access
 }
 
@@ -22,6 +23,18 @@ export default {
       // Handle CORS preflight
       if (request.method === "OPTIONS") {
         return new Response(null, { headers: corsHeaders });
+      }
+
+      // Cache version endpoint (public, no auth required)
+      if (url.pathname === "/api/cache-version") {
+        const version = await env.CACHE_VERSION.get("thumbnail_version") || Date.now().toString();
+        return new Response(JSON.stringify({ version }), {
+          headers: {
+            ...corsHeaders,
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache"
+          }
+        });
       }
 
       // Login page and authentication

--- a/workers/viewer/src/templates/gallery.ts
+++ b/workers/viewer/src/templates/gallery.ts
@@ -363,11 +363,17 @@ export function getJavaScript() {
     let currentIndex = 0;
     let lightboxModal = null;
     let hlsInstance = null;
+    let cacheVersion = '';
     const isMobile = window.matchMedia('(max-width: 768px)').matches;
-    
+
     // Load media from API
     async function loadMedia() {
         try {
+            // Fetch cache version for thumbnail URLs
+            const versionResponse = await fetch('/api/cache-version');
+            const versionData = await versionResponse.json();
+            cacheVersion = versionData.version;
+
             const response = await fetch('/api/media');
             const data = await response.json();
             mediaItems = data.media;
@@ -401,13 +407,13 @@ export function getJavaScript() {
             if (isVideo) {
                 // Use thumbnail for videos in grid view instead of loading full video
                 return '<div class="gallery-item" data-index="' + dataIndex + '" ' + onclickAttr + '>' +
-                    '<img class="media-lazy" data-src="/api/thumbnail/' + item.key + '?size=medium" alt="' + item.name + '" loading="lazy">' +
+                    '<img class="media-lazy" data-src="/api/thumbnail/' + item.key + '?size=medium&v=' + cacheVersion + '" alt="' + item.name + '" loading="lazy">' +
                     '<div class="play-overlay"></div>' +
                     '<div class="video-indicator">📹 Video</div>' +
                     '</div>';
             } else {
                 return '<div class="gallery-item" data-index="' + dataIndex + '" ' + onclickAttr + '>' +
-                    '<img class="media-lazy" data-src="/api/thumbnail/' + item.key + '?size=medium" alt="' + item.name + '" loading="lazy">' +
+                    '<img class="media-lazy" data-src="/api/thumbnail/' + item.key + '?size=medium&v=' + cacheVersion + '" alt="' + item.name + '" loading="lazy">' +
                     '</div>';
             }
         }).join('');

--- a/workers/viewer/wrangler.toml
+++ b/workers/viewer/wrangler.toml
@@ -14,6 +14,12 @@ binding = "DB"
 database_name = "wedding-photos-metadata"
 database_id = "150012ba-e8d4-4e02-8769-aafd24fe08d0"
 
+# KV namespace for cache versioning
+[[kv_namespaces]]
+binding = "CACHE_VERSION"
+id = "cf132b95f9434658b98935f880a0b299"
+preview_id = "0e495b6647154a1a8532b0d3fafb7c82"
+
 # Development settings
 [dev]
 port = 8787


### PR DESCRIPTION
Implement cache versioning system to force browser cache refresh when thumbnails are regenerated. Uses KV namespace to store version timestamp that is appended to thumbnail URLs.

- Add CACHE_VERSION KV namespace binding
- Add /api/cache-version endpoint to serve current version
- Frontend fetches version on load and appends to thumbnail URLs
- Thumbnail generation script updates version when using --force flag

Fixes issue where 30-day cache prevented users from seeing regenerated thumbnails without hard refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)