### PR TITLE
Fix iOS preprocessing

### DIFF
--- a/workers/album/src/index.html
+++ b/workers/album/src/index.html
@@ -205,7 +205,7 @@
         <div class="upload-area" onclick="document.getElementById('fileInput').click()">
             <div class="upload-icon">📸</div>
             <div class="upload-text">Tap to add photos or videos</div>
-            <input type="file" id="fileInput" multiple accept="image/*,video/*">
+            <input type="file" id="fileInput" multiple>
         </div>
 
         <div id="photoGrid" class="photo-grid"></div>


### PR DESCRIPTION
iOS automatically transcodes images/videos when accept="image/*,video/*" is set, causing slowness and failures when selecting many files. Removing the accept attribute allows raw file upload while maintaining server-side validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)