### PR TITLE
Generate video thumbnails from pending tasks

### DIFF
--- a/scripts/generate-thumbnails-from-pending.mjs
+++ b/scripts/generate-thumbnails-from-pending.mjs
@@ -15,7 +15,7 @@ async function main() {
   const worker = await unstable_dev('scripts/process-locally.ts', {
     config: 'scripts/wrangler-process-locally.toml',
     experimental: { disableExperimentalWarning: true },
-    local: false
+    local: true
   });
 
   try {

--- a/scripts/lib/thumbnail-generator.mjs
+++ b/scripts/lib/thumbnail-generator.mjs
@@ -16,7 +16,7 @@ const FFMPEG_CMD = 'ffmpeg';
 const FFPROBE_CMD = 'ffprobe';
 
 // ---------- Helper utilities ----------
-const SCALE_FILTER = 'scale=min(iw,1920):-2';
+const SCALE_FILTER = 'scale=1920:-2:force_original_aspect_ratio=decrease';
 
 function buildFfprobeJsonArgs(videoPath) {
   return [


### PR DESCRIPTION
Fix FFmpeg scale filter syntax to correctly generate video thumbnails.

The previous `scale=min(iw,1920):-2` filter was invalid FFmpeg syntax, causing thumbnail generation to fail with a "No such filter" error. This PR updates the filter to `scale=1920:-2:force_original_aspect_ratio=decrease` to properly scale videos to a maximum width of 1920 pixels while preserving aspect ratio. Additionally, the `unstable_dev` worker is now configured to run locally for development.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c57c9d-f671-42bf-9091-a6735a79cd8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45c57c9d-f671-42bf-9091-a6735a79cd8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

