### PR TITLE
Fix auth redirect to preserve original destination URL

### DIFF
--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -179,7 +179,8 @@ export default {
 
   function isValidReturnTo(returnTo: string): boolean {
     // Must start with / and not start with // (to prevent protocol-relative URLs)
-    return returnTo.startsWith('/') && !returnTo.startsWith('//');
+    // Must not contain : to prevent javascript:, data:, and other protocol handlers
+    return returnTo.startsWith('/') && !returnTo.startsWith('//') && !returnTo.includes(':');
   }
 
   function escapeHtml(str: string): string {


### PR DESCRIPTION
## Summary

Fixed the auth redirect issue where deep-linked URLs weren't preserved after authentication. Users are now correctly redirected back to their original destination after logging in.

## Changes

- Pass original URL as returnTo query parameter when redirecting to login
- Store returnTo in hidden form field on login page
- Redirect to original URL after successful authentication
- Add HTML escaping for security
- Update tests to verify deep link redirect behavior

Fixes #15

Generated with [Claude Code](https://claude.ai/code)