### PR TITLE
Fix CORS issue by adding PAGES_ORIGIN environment variable

### DIFF
--- a/workers/viewer/wrangler.toml
+++ b/workers/viewer/wrangler.toml
@@ -20,6 +20,10 @@ binding = "CACHE_VERSION"
 id = "cf132b95f9434658b98935f880a0b299"
 preview_id = "0e495b6647154a1a8532b0d3fafb7c82"
 
+# Environment variables
+[vars]
+PAGES_ORIGIN = "https://release.jessandsourabh.pages.dev"
+
 # Development settings
 [dev]
 port = 8787


### PR DESCRIPTION
## Summary
- Adds `PAGES_ORIGIN` environment variable to viewer worker configuration
- Fixes CORS errors when frontend at `https://release.jessandsourabh.pages.dev` attempts to access the viewer API at `https://viewer.shirhatti.workers.dev`

## Test plan
- [x] Tests pass locally
- [ ] Verify CORS headers are present after deployment
- [ ] Confirm frontend can successfully fetch from `/api/media`

🤖 Generated with [Claude Code](https://claude.com/claude-code)