### PR TITLE
Support wildcard CORS for Cloudflare Pages preview deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install
 
       - name: Deploy Viewer Worker
-        run: cd workers/viewer && npx wrangler deploy --var PAGES_ORIGIN:https://jessandsourabh.pages.dev
+        run: cd workers/viewer && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: f974b5257387abc8b6e9e66734f27ec3

--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -34,8 +34,10 @@ export default {
       const allowedOrigins: string[] = [];
 
       // Allow Pages origin if configured (for production Cloudflare Pages integration)
+      // Supports comma-separated list of origins for multiple environments
       if (env.PAGES_ORIGIN) {
-        allowedOrigins.push(env.PAGES_ORIGIN);
+        const origins = env.PAGES_ORIGIN.split(",").map(o => o.trim());
+        allowedOrigins.push(...origins);
       }
 
       // Only allow localhost when explicitly enabled (for development)
@@ -48,7 +50,11 @@ export default {
       }
 
       // Check if request origin is allowed
-      const isAllowedOrigin = allowedOrigins.includes(requestOrigin);
+      // Support wildcard subdomains for Cloudflare Pages previews (*.jessandsourabh.pages.dev)
+      const isAllowedOrigin = allowedOrigins.includes(requestOrigin) ||
+        (requestOrigin.startsWith("https://") &&
+         (requestOrigin === "https://jessandsourabh.pages.dev" ||
+          requestOrigin.endsWith(".jessandsourabh.pages.dev")));
 
       const corsHeaders: Record<string, string> = {
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS",


### PR DESCRIPTION
## Summary
- Adds support for all `*.jessandsourabh.pages.dev` subdomains to handle Cloudflare Pages preview deployments
- Supports comma-separated `PAGES_ORIGIN` values for additional flexibility  
- Simplifies deploy workflow by removing `--var` override (now uses wrangler.toml value)

## Changes
- Updated CORS origin check to allow any subdomain of `jessandsourabh.pages.dev`
- Added support for comma-separated origins in `PAGES_ORIGIN` environment variable
- Removed hardcoded `--var PAGES_ORIGIN` override from GitHub Actions workflow

## Test plan
- [x] Tests pass locally
- [ ] Verify CORS headers work for `https://jessandsourabh.pages.dev`
- [ ] Verify CORS headers work for `https://release.jessandsourabh.pages.dev`
- [ ] Verify CORS headers work for any preview deployment (e.g., `https://<branch>.jessandsourabh.pages.dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)