### PR TITLE
Fix AirPlay not showing on iOS Safari

### DIFF
--- a/pages/gallery/src/components/Lightbox.tsx
+++ b/pages/gallery/src/components/Lightbox.tsx
@@ -198,8 +198,6 @@ export function Lightbox({ media, initialIndex, onClose }: LightboxProps) {
             controls
             className="max-h-[90vh] max-w-full"
             playsInline
-            disableRemotePlayback={false}
-            {...({ 'x-webkit-airplay': 'allow' } as any)}
           />
         ) : (
           <img


### PR DESCRIPTION
Remove disableRemotePlayback and x-webkit-airplay attributes from video element.
The disableRemotePlayback attribute, even when set to false, can prevent AirPlay
from appearing in Safari's video controls. By removing it entirely, we allow the
browser's default behavior which enables AirPlay when available devices are detected.

The x-webkit-airplay attribute is deprecated and no longer needed in modern Safari.