### PR TITLE
Add explicit AirPlay and Google Cast buttons to video player

### DIFF
--- a/pages/gallery/src/components/Lightbox.tsx
+++ b/pages/gallery/src/components/Lightbox.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect } from 'react'
 import { ChevronLeft, ChevronRight, X } from 'lucide-react'
-import { MediaPlayer, MediaProvider, isHLSProvider } from '@vidstack/react'
+import {
+  MediaPlayer,
+  MediaProvider,
+  isHLSProvider,
+  AirPlayButton,
+  GoogleCastButton
+} from '@vidstack/react'
 import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default'
 import '@vidstack/react/player/styles/default/theme.css'
 import '@vidstack/react/player/styles/default/layouts/video.css'
@@ -199,7 +205,13 @@ export function Lightbox({ media, initialIndex, onClose }: LightboxProps) {
             }}
           >
             <MediaProvider />
-            <DefaultVideoLayout icons={defaultLayoutIcons} />
+            <DefaultVideoLayout
+              icons={defaultLayoutIcons}
+              slots={{
+                airPlayButton: <AirPlayButton />,
+                googleCastButton: <GoogleCastButton />,
+              }}
+            />
           </MediaPlayer>
         ) : imageError ? (
           <div className="flex flex-col items-center justify-center text-zinc-400">


### PR DESCRIPTION
Explicitly add AirPlay and Google Cast buttons to DefaultVideoLayout using the slots prop to ensure they appear on supported platforms.

Changes:
- Import AirPlayButton and GoogleCastButton from @vidstack/react
- Add buttons to DefaultVideoLayout via slots configuration
- AirPlayButton will appear on iOS/macOS Safari when AirPlay is available
- GoogleCastButton will appear when Chromecast devices are detected

This ensures remote playback functionality is visible and accessible to users on Apple devices and those with Chromecast.