### PR TITLE
Fix AirPlay button visibility with ExtendedHls class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6678,6 +6678,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -10363,6 +10369,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cookie": "^0.7.2",
+        "hls.js": "^1.5.15",
         "lucide-react": "^0.447.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/pages/gallery/package.json
+++ b/pages/gallery/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cookie": "^0.7.2",
+    "hls.js": "^1.5.15",
     "lucide-react": "^0.447.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pages/gallery/src/components/Lightbox.tsx
+++ b/pages/gallery/src/components/Lightbox.tsx
@@ -10,9 +10,21 @@ import {
 import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default'
 import '@vidstack/react/player/styles/default/theme.css'
 import '@vidstack/react/player/styles/default/layouts/video.css'
+import Hls from 'hls.js'
 import { MediaItem } from '@/types'
 import { Button } from '@/components/ui/button'
 import { MOBILE_BREAKPOINT, LIGHTBOX_SIZES } from '@/lib/constants'
+
+// Extended HLS class to enable AirPlay support
+// Fix for: https://github.com/vidstack/player/issues/1522
+class ExtendedHls extends Hls {
+  attachMedia(media: HTMLMediaElement) {
+    super.attachMedia(media)
+    // Enable remote playback (AirPlay) and autoplay for iOS compatibility
+    media.disableRemotePlayback = false
+    media.autoplay = true
+  }
+}
 
 const API_BASE = import.meta.env.VITE_API_BASE || ''
 
@@ -190,9 +202,10 @@ export function Lightbox({ media, initialIndex, onClose }: LightboxProps) {
             className="max-h-[90vh] max-w-full"
             onProviderChange={(provider) => {
               // Configure HLS.js when it's being used (non-Safari browsers)
-              // Vidstack will automatically load hls.js from CDN
+              // Use ExtendedHls to enable AirPlay support
               // Note: Safari uses native HLS and relies on token in URL (above)
               if (isHLSProvider(provider)) {
+                provider.library = ExtendedHls
                 provider.config = {
                   enableWorker: true,
                   lowLatencyMode: false,


### PR DESCRIPTION
The AirPlay button wasn't appearing because HLS.js sets disableRemotePlayback=true by default, which prevents the Remote Playback API from detecting AirPlay availability.

Solution:
- Create ExtendedHls class that extends hls.js
- Override attachMedia to set disableRemotePlayback=false and autoplay=true
- Use ExtendedHls as the provider library instead of CDN version

This fix is based on the workaround from:
https://github.com/vidstack/player/issues/1522

Changes:
- Add ExtendedHls class with AirPlay-compatible attachMedia override
- Configure provider to use ExtendedHls library
- Re-add hls.js as direct dependency (needed for class extension)

Now the AirPlay button will properly appear on iOS/macOS Safari when AirPlay devices are available on the network.