### PR TITLE
Add TypeScript compilation check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,23 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: TypeScript check - workers/viewer
+        run: npx tsc --noEmit -p workers/viewer
+
+      - name: TypeScript check - workers/video-streaming
+        run: npx tsc --noEmit -p workers/video-streaming
+
+      - name: TypeScript check - workers/album
+        run: npx tsc --noEmit -p workers/album
+
+      - name: TypeScript check - packages/auth
+        run: npx tsc --noEmit -p packages/auth
+
+      - name: TypeScript check - packages/shared-video-lib
+        run: npx tsc --noEmit -p packages/shared-video-lib
+
+      - name: Build pages/gallery
+        run: npm run build:pages
+
       - name: Run tests
         run: npm test -- --run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,23 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: TypeScript check - workers/viewer
-        run: npx tsc --noEmit -p workers/viewer
-
-      - name: TypeScript check - workers/video-streaming
-        run: npx tsc --noEmit -p workers/video-streaming
-
-      - name: TypeScript check - workers/album
-        run: npx tsc --noEmit -p workers/album
-
-      - name: TypeScript check - packages/auth
-        run: npx tsc --noEmit -p packages/auth
-
-      - name: TypeScript check - packages/shared-video-lib
-        run: npx tsc --noEmit -p packages/shared-video-lib
-
-      - name: Build pages/gallery
-        run: npm run build:pages
+      - name: TypeScript check - all projects
+        run: npx tsc --build
 
       - name: Run tests
         run: npm test -- --run

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Thumbs.db
 # Build outputs
 dist/
 .cache/
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
 
 # Local database files
 *.db

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tseslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 
 export default [
-  { ignores: [".wrangler/tmp/**"] },
+  { ignores: [".wrangler/tmp/**", "**/*.d.ts"] },
   {
     files: [
       "workers/*/src/**/*.{ts,tsx}"

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "composite": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/shared-video-lib/tsconfig.json
+++ b/packages/shared-video-lib/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "node",
-    "types": ["@cloudflare/workers-types"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "composite": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/pages/gallery/tsconfig.json
+++ b/pages/gallery/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "module": "ES2020",
-    "types": ["@cloudflare/workers-types"]
-  }
+  "files": [],
+  "references": [
+    { "path": "./workers/viewer" },
+    { "path": "./workers/video-streaming" },
+    { "path": "./workers/album" },
+    { "path": "./packages/auth" },
+    { "path": "./packages/shared-video-lib" },
+    { "path": "./pages/gallery" }
+  ]
 }

--- a/workers/album/src/types.d.ts
+++ b/workers/album/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.html" {
+  const content: string;
+  export default content;
+}

--- a/workers/album/tsconfig.json
+++ b/workers/album/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*"]
 }

--- a/workers/video-streaming/tsconfig.json
+++ b/workers/video-streaming/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*"]
 }

--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -166,8 +166,8 @@ export default {
         filename: string;
         type: string;
         size: number | null;
-        uploadedAt: string | null;
-        dateTaken: string | null;
+        uploadedAt: Date | null;
+        dateTaken: Date | null;
         cameraMake: string | null;
         cameraModel: string | null;
         width: number | null;
@@ -205,8 +205,8 @@ export default {
           name: row.filename,
           size: row.size ?? 0,
           type: row.type,
-          uploadedAt: row.uploadedAt ?? "",
-          dateTaken: row.dateTaken,
+          uploadedAt: row.uploadedAt?.toISOString() ?? "",
+          dateTaken: row.dateTaken?.toISOString() ?? null,
           cameraMake: row.cameraMake,
           cameraModel: row.cameraModel,
         };

--- a/workers/viewer/tsconfig.json
+++ b/workers/viewer/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test/**/*"]
 }


### PR DESCRIPTION
Run tsc --noEmit for all workers and packages, plus build for pages. This catches TypeScript errors across the entire codebase before merge.